### PR TITLE
Fix no line to end error

### DIFF
--- a/default.mla-paper
+++ b/default.mla-paper
@@ -113,7 +113,8 @@ $if(date)$
 $endif$
 
 \begin{document}
-\begin{mla}{$authorfirst$}{$authorlast$}{$professorlast$}{$class$}{$date$}{$title$}
+\begin{mla}
+{$authorfirst$}{$authorlast$}{$professorlast$}{$class$}{$date$}{$title$}
 
 $for(include-before)$
 $include-before$


### PR DESCRIPTION
By placing the document metadata on a line beneath the begin{mla} statement the document correctly compiles to pdf
