### PR TITLE
default.latex needs tightlist command for pandoc

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -102,6 +102,8 @@ $endif$
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 $if(numbersections)$
 $else$
 \setcounter{secnumdepth}{0}


### PR DESCRIPTION
pandoc now requires the definition for the tightlist command in it's pandoc templates
